### PR TITLE
scrape data before autoloading

### DIFF
--- a/bin/dump.php
+++ b/bin/dump.php
@@ -2,17 +2,34 @@
 
 namespace PHPWatch\SymbolData;
 
+$PHPWatchSymbols = [
+    'ext' => get_loaded_extensions(),
+    'const' => get_defined_constants(true),
+    'class' => get_declared_classes(),
+    'trait' => get_declared_traits(),
+    'interface' => get_declared_interfaces(),
+    'function' => get_defined_functions()['internal'],
+    'ini' => ini_get_all(),
+    'attribute' => [],
+    'phpinfo' => (function(): string {
+        ob_start();
+        // Do not include env of build info as they change in every build and run
+        phpinfo(INFO_CREDITS|INFO_LICENSE|INFO_MODULES|INFO_CONFIGURATION);
+        return ob_get_clean();
+    })(),
+];
+
 require __DIR__ . '/../vendor/autoload.php';
 
 $output = new Output();
 
-$output->addData(ExtensionListSource::NAME, ExtensionListSource::getAllData());
-$output->addData(ConstantsSource::NAME, ConstantsSource::getAllData());
-$output->addData(ClassesListSource::NAME, ClassesListSource::getAllData());
-$output->addData(TraitsListSource::NAME, TraitsListSource::getAllData());
-$output->addData(InterfacesListSource::NAME, InterfacesListSource::getAllData());
-$output->addData(FunctionsListSource::NAME, FunctionsListSource::getAllData());
-$output->addData(INIListSource::NAME, INIListSource::getAllData());
+$output->addData(ExtensionListSource::NAME, $PHPWatchSymbols['ext']);
+$output->addData(ConstantsSource::NAME, $PHPWatchSymbols['const']);
+$output->addData(ClassesListSource::NAME, $PHPWatchSymbols['class']);
+$output->addData(TraitsListSource::NAME, $PHPWatchSymbols['trait']);
+$output->addData(InterfacesListSource::NAME, $PHPWatchSymbols['interface']);
+$output->addData(FunctionsListSource::NAME, $PHPWatchSymbols['function']);
+$output->addData(INIListSource::NAME, $PHPWatchSymbols['ini']);
 $output->addData(AttributesListSource::NAME, AttributesListSource::getAllData());
 $output->addData(PHPInfoSource::NAME, PHPInfoSource::getAllData());
 

--- a/src/Output.php
+++ b/src/Output.php
@@ -19,7 +19,7 @@ class Output {
 
         foreach ($this->data as $key => $data) {
             $data = var_export($data, true);
-            $data = "<?php \r\n\r\nreturn " . $data;
+            $data = "<?php \n\nreturn " . $data . ";\n";
             file_put_contents($this->dir . '/' . $key . '.php', $data);
         }
     }

--- a/src/Output.php
+++ b/src/Output.php
@@ -19,7 +19,7 @@ class Output {
 
         foreach ($this->data as $key => $data) {
             $data = var_export($data, true);
-            $data = "<?php \n\nreturn " . $data . ";\n";
+            $data = "<?php\n\nreturn " . $data . ";\n";
             file_put_contents($this->dir . '/' . $key . '.php', $data);
         }
     }


### PR DESCRIPTION
Hey @Ayesh,

This PR will scrape the data before requiring the `autoload.php`. This way we don't have to filter out classes and interfaces defined by us or a 3rd party library. It also added a missing `;` at the end in the exported files.

Please note that most of the classes like `ExtensionListSource::getAllData()`, `ClassesListSource::getAllData()`, and so on aren't needed anymore. But we still need some filtering on the attributes list and phpinfo.

I could rebuild this classes as middleware or visitor classes that can alter the `$PHPWatchSymbols` variable. This way we could later implement middlewares for "Function Stub Source" and a "Class Stub Source" using Reflection API you've mentioned in #1. What do you think?

Btw: The list of defined symbols varies depending on the available extensions. Therefore, I suggest that we document the list of used extension in `composer.json` and `.github/workflows/symbol-update.yml`. Maybe we could also create a Dockerfiles with the supported extensions.