### PR TITLE
Add more symbol details in separate files

### DIFF
--- a/bin/dump.php
+++ b/bin/dump.php
@@ -34,6 +34,7 @@ $output->addData(AttributesListSource::NAME, AttributesListSource::getAllData())
 $output->addData(PHPInfoSource::NAME, PHPInfoSource::getAllData());
 
 ExtensionListSource::handleExtensionList($PHPWatchSymbols['ext'], $output);
+ConstantsSource::handleGroupedConstantList($PHPWatchSymbols['const'], $output);
 ClassesListSource::handleClassList($PHPWatchSymbols['class'], $output);
 InterfacesListSource::handleInterfaceList($PHPWatchSymbols['interface'], $output);
 

--- a/bin/dump.php
+++ b/bin/dump.php
@@ -36,6 +36,7 @@ $output->addData(PHPInfoSource::NAME, PHPInfoSource::getAllData());
 ExtensionListSource::handleExtensionList($PHPWatchSymbols['ext'], $output);
 ConstantsSource::handleGroupedConstantList($PHPWatchSymbols['const'], $output);
 ClassesListSource::handleClassList($PHPWatchSymbols['class'], $output);
+TraitsListSource::handleTraitList($PHPWatchSymbols['trait'], $output);
 InterfacesListSource::handleInterfaceList($PHPWatchSymbols['interface'], $output);
 
 $output->write();

--- a/bin/dump.php
+++ b/bin/dump.php
@@ -33,4 +33,6 @@ $output->addData(INIListSource::NAME, $PHPWatchSymbols['ini']);
 $output->addData(AttributesListSource::NAME, AttributesListSource::getAllData());
 $output->addData(PHPInfoSource::NAME, PHPInfoSource::getAllData());
 
+ClassesListSource::handleClassList($PHPWatchSymbols['class'], $output);
+
 $output->write();

--- a/bin/dump.php
+++ b/bin/dump.php
@@ -38,5 +38,6 @@ ConstantsSource::handleGroupedConstantList($PHPWatchSymbols['const'], $output);
 ClassesListSource::handleClassList($PHPWatchSymbols['class'], $output);
 TraitsListSource::handleTraitList($PHPWatchSymbols['trait'], $output);
 InterfacesListSource::handleInterfaceList($PHPWatchSymbols['interface'], $output);
+FunctionsListSource::handleFunctionList($PHPWatchSymbols['function'], $output);
 
 $output->write();

--- a/bin/dump.php
+++ b/bin/dump.php
@@ -2,17 +2,34 @@
 
 namespace PHPWatch\SymbolData;
 
+$PHPWatchSymbols = [
+    'ext' => get_loaded_extensions(),
+    'const' => get_defined_constants(true),
+    'class' => get_declared_classes(),
+    'trait' => get_declared_traits(),
+    'interface' => get_declared_interfaces(),
+    'function' => get_defined_functions()['internal'],
+    'ini' => ini_get_all(),
+    'attribute' => [],
+    'phpinfo' => (function(): string {
+        ob_start();
+        // Do not include env of build info as they change in every build and run
+        phpinfo(INFO_CREDITS|INFO_LICENSE|INFO_MODULES|INFO_CONFIGURATION);
+        return ob_get_clean();
+    })(),
+];
+
 require __DIR__ . '/../vendor/autoload.php';
 
 $output = new Output();
 
-$output->addData(ExtensionListSource::NAME, ExtensionListSource::getAllData());
-$output->addData(ConstantsSource::NAME, ConstantsSource::getAllData());
-$output->addData(ClassesListSource::NAME, ClassesListSource::getAllData());
-$output->addData(TraitsListSource::NAME, TraitsListSource::getAllData());
-$output->addData(InterfacesListSource::NAME, InterfacesListSource::getAllData());
-$output->addData(FunctionsListSource::NAME, FunctionsListSource::getAllData());
-$output->addData(INIListSource::NAME, INIListSource::getAllData());
+$output->addData(ExtensionListSource::NAME, $PHPWatchSymbols['ext']);
+$output->addData(ConstantsSource::NAME, $PHPWatchSymbols['const']);
+$output->addData(ClassesListSource::NAME, $PHPWatchSymbols['class']);
+$output->addData(TraitsListSource::NAME, $PHPWatchSymbols['trait']);
+$output->addData(InterfacesListSource::NAME, $PHPWatchSymbols['interface']);
+$output->addData(FunctionsListSource::NAME, $PHPWatchSymbols['function']);
+$output->addData(INIListSource::NAME, $PHPWatchSymbols['ini']);
 $output->addData(AttributesListSource::NAME, AttributesListSource::getAllData());
 $output->addData(PHPInfoSource::NAME, PHPInfoSource::getAllData());
 

--- a/bin/dump.php
+++ b/bin/dump.php
@@ -10,7 +10,24 @@ $PHPWatchSymbols = [
     'interface' => get_declared_interfaces(),
     'function' => get_defined_functions()['internal'],
     'ini' => ini_get_all(),
-    'attribute' => [],
+    // TODO: Find a way to dynamicly get the attributes
+    'attribute' => (function(): array {
+        $data = [];
+
+        if (class_exists('ReturnTypeWillChange')) {
+            $data[] = 'ReturnTypeWillChange';
+        }
+
+        if (class_exists('AllowDynamicProperties')) {
+            $data[] = 'AllowDynamicProperties';
+        }
+
+        if (class_exists('SensitiveParameter')) {
+            $data[] = 'SensitiveParameter';
+        }
+
+        return $data;
+    })(),
     'phpinfo' => (function(): string {
         ob_start();
         // Do not include env of build info as they change in every build and run
@@ -23,21 +40,14 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $output = new Output();
 
-$output->addData(ExtensionListSource::NAME, $PHPWatchSymbols['ext']);
-$output->addData(ConstantsSource::NAME, $PHPWatchSymbols['const']);
-$output->addData(ClassesListSource::NAME, $PHPWatchSymbols['class']);
-$output->addData(TraitsListSource::NAME, $PHPWatchSymbols['trait']);
-$output->addData(InterfacesListSource::NAME, $PHPWatchSymbols['interface']);
-$output->addData(FunctionsListSource::NAME, $PHPWatchSymbols['function']);
-$output->addData(INIListSource::NAME, $PHPWatchSymbols['ini']);
-$output->addData(AttributesListSource::NAME, AttributesListSource::getAllData());
-$output->addData(PHPInfoSource::NAME, PHPInfoSource::getAllData());
-
 ExtensionListSource::handleExtensionList($PHPWatchSymbols['ext'], $output);
 ConstantsSource::handleGroupedConstantList($PHPWatchSymbols['const'], $output);
 ClassesListSource::handleClassList($PHPWatchSymbols['class'], $output);
 TraitsListSource::handleTraitList($PHPWatchSymbols['trait'], $output);
 InterfacesListSource::handleInterfaceList($PHPWatchSymbols['interface'], $output);
 FunctionsListSource::handleFunctionList($PHPWatchSymbols['function'], $output);
+INIListSource::handleIniList($PHPWatchSymbols['ini'], $output);
+AttributesListSource::handleAttributeList($PHPWatchSymbols['attribute'], $output);
+PHPInfoSource::handlePhpinfoString($PHPWatchSymbols['phpinfo'], $output);
 
 $output->write();

--- a/bin/dump.php
+++ b/bin/dump.php
@@ -33,6 +33,7 @@ $output->addData(INIListSource::NAME, $PHPWatchSymbols['ini']);
 $output->addData(AttributesListSource::NAME, AttributesListSource::getAllData());
 $output->addData(PHPInfoSource::NAME, PHPInfoSource::getAllData());
 
+ExtensionListSource::handleExtensionList($PHPWatchSymbols['ext'], $output);
 ClassesListSource::handleClassList($PHPWatchSymbols['class'], $output);
 InterfacesListSource::handleInterfaceList($PHPWatchSymbols['interface'], $output);
 

--- a/bin/dump.php
+++ b/bin/dump.php
@@ -34,5 +34,6 @@ $output->addData(AttributesListSource::NAME, AttributesListSource::getAllData())
 $output->addData(PHPInfoSource::NAME, PHPInfoSource::getAllData());
 
 ClassesListSource::handleClassList($PHPWatchSymbols['class'], $output);
+InterfacesListSource::handleInterfaceList($PHPWatchSymbols['interface'], $output);
 
 $output->write();

--- a/meta/attributes/AllowDynamicProperties.php
+++ b/meta/attributes/AllowDynamicProperties.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'type' => 'attribute',
+    'name' => 'AllowDynamicProperties',
+    'description' => '',
+    'keywords' => [],
+    'added' => '8.2',
+    'deprecated' => null,
+    'removed' => null,
+    'resources' => [
+        [
+            'name' => 'AllowDynamicProperties attribute (php.net)',
+            'url' => 'https://www.php.net/manual/en/class.allowdynamicproperties.php',
+        ],
+    ],
+];

--- a/meta/attributes/ReturnTypeWillChange.php
+++ b/meta/attributes/ReturnTypeWillChange.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'type' => 'attribute',
+    'name' => 'ReturnTypeWillChange',
+    'description' => '',
+    'keywords' => [],
+    'added' => '8.1',
+    'deprecated' => null,
+    'removed' => null,
+    'resources' => [
+        [
+            'name' => 'ReturnTypeWillChange attribute (php.net)',
+            'url' => 'https://www.php.net/manual/en/class.returntypewillchange.php',
+        ],
+    ],
+];

--- a/meta/attributes/SensitiveParameter.php
+++ b/meta/attributes/SensitiveParameter.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'type' => 'attribute',
+    'name' => 'SensitiveParameter',
+    'description' => 'This attribute is used to mark a parameter that is sensitive and should have its value redacted if present in a stack trace.',
+    'keywords' => [],
+    'added' => '8.2',
+    'deprecated' => null,
+    'removed' => null,
+    'resources' => [
+        [
+            'name' => 'SensitiveParameter attribute (php.net)',
+            'url' => 'https://www.php.net/manual/en/class.sensitiveparameter.php',
+        ],
+    ],
+];

--- a/meta/classes/CurlHandle.php
+++ b/meta/classes/CurlHandle.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'type' => 'class',
+    'name' => 'CurlHandle',
+    'description' => '',
+    'keywords' => [],
+    'added' => '8.0',
+    'deprecated' => null,
+    'removed' => null,
+    'resources' => [
+        [
+            'name' => 'CurlHandle class (php.net)',
+            'url' => 'https://www.php.net/manual/en/class.curlhandle.php',
+        ],
+    ],
+];

--- a/meta/classes/SensitiveParameterValue.php
+++ b/meta/classes/SensitiveParameterValue.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'type' => 'class',
+    'name' => 'SensitiveParameterValue',
+    'description' => 'The SensitiveParameterValue class allows wrapping sensitive values to protect them against accidental exposure.',
+    'keywords' => [],
+    'added' => '8.2',
+    'deprecated' => null,
+    'removed' => null,
+    'resources' => [
+        [
+            'name' => 'SensitiveParameterValue class (php.net)',
+            'url' => 'https://www.php.net/manual/en/class.sensitiveparametervalue.php',
+        ],
+    ],
+];

--- a/meta/interfaces/Throwable.php
+++ b/meta/interfaces/Throwable.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'type' => 'interface',
+    'name' => 'Throwable',
+    'description' => '',
+    'keywords' => [],
+    'added' => '7.0',
+    'deprecated' => null,
+    'removed' => null,
+    'resources' => [
+        [
+            'name' => 'Throwable class (php.net)',
+            'url' => 'https://www.php.net/manual/en/class.throwable.php',
+        ],
+    ],
+];

--- a/src/AttributesListSource.php
+++ b/src/AttributesListSource.php
@@ -6,6 +6,58 @@ use ReflectionClass;
 
 class AttributesListSource extends DataSourceBase {
     const NAME = 'attribute';
+
+    public static function handleAttributeList(array $attributeList, Output $output)
+    {
+        $output->addData('attribute', $attributeList);
+
+        foreach ($attributeList as $name) {
+            $reflection = new ReflectionClass($name);
+
+            // Handle namespaces
+            $filename = str_replace('\\', '/', $name);
+            $metafile = realpath(__DIR__ . '/../meta/attributes/' . $filename . '.php');
+
+            // maybe embed custom meta data
+            if ($metafile !== false && file_exists($metafile)) {
+                $meta = include($metafile);
+            } else {
+                // embed generic meta data
+                $meta = [
+                    'type' => 'class',
+                    'name' => $reflection->getName(),
+                    'description' => '',
+                    'keywords' => [],
+                    'added' => '0.0',
+                    'deprecated' => null,
+                    'removed' => null,
+                    'resources' => static::generateResources($name),
+                ];
+            }
+
+            $output->addData('attributes/' . $filename, [
+                'type' => 'class',
+                'name' => $reflection->getName(),
+                'meta' => $meta,
+                'interfaces' => [], // #todo
+                'constants' => [], // #todo
+                'properties' => [], // #todo
+                'traits' => [], // #todo
+                'methods' => [], // #todo
+            ]);
+        }
+    }
+
+    private static function generateResources(string $classname): array
+    {
+        return [
+            [
+                'name' => $classname . ' attribute (php.net)',
+                'url' => 'https://www.php.net/manual/class.' . strtolower($classname) . '.php',
+            ],
+        ];
+    }
+
     protected function gatherData() {
         if (!class_exists('Attribute', false)) {
             return [];

--- a/src/ClassesListSource.php
+++ b/src/ClassesListSource.php
@@ -10,14 +10,33 @@ class ClassesListSource extends DataSourceBase {
     public static function handleClassList(array $classList, Output $output)
     {
         foreach ($classList as $name) {
+            $reflection = new ReflectionClass($name);
+
             // Handle namespaces
             $filename = str_replace('\\', '/', $name);
+            $metafile = realpath(__DIR__ . '/../meta/classes/' . $filename . '.php');
 
-            $reflection = new ReflectionClass($name);
+            // maybe embed custom meta data
+            if ($metafile !== false && file_exists($metafile)) {
+                $meta = include($metafile);
+            } else {
+                // embed generic meta data
+                $meta = [
+                    'type' => 'class',
+                    'name' => $reflection->getName(),
+                    'description' => '',
+                    'keywords' => [],
+                    'added' => '0.0',
+                    'deprecated' => null,
+                    'removed' => null,
+                    'resources' => [],
+                ];
+            }
 
             $output->addData('classes/' . $filename, [
                 'type' => 'class',
                 'name' => $reflection->getName(),
+                'meta' => $meta,
                 'interfaces' => [], // #todo
                 'constants' => [], // #todo
                 'properties' => [], // #todo

--- a/src/ClassesListSource.php
+++ b/src/ClassesListSource.php
@@ -29,7 +29,7 @@ class ClassesListSource extends DataSourceBase {
                     'added' => '0.0',
                     'deprecated' => null,
                     'removed' => null,
-                    'resources' => [],
+                    'resources' => static::generateResources($name),
                 ];
             }
 
@@ -43,6 +43,23 @@ class ClassesListSource extends DataSourceBase {
                 'methods' => [], // #todo
             ]);
         }
+    }
+
+    private static function generateResources(string $classname): array
+    {
+        // ignore classes without manual entry
+        if (in_array($classname, [
+            '__PHP_Incomplete_Class',
+        ])) {
+            return [];
+        }
+
+        return [
+            [
+                'name' => $classname . ' class (php.net)',
+                'url' => 'https://www.php.net/manual/class.' . str_replace('\\', '-', strtolower($classname)) . '.php',
+            ],
+        ];
     }
 
     protected function gatherData() {

--- a/src/ClassesListSource.php
+++ b/src/ClassesListSource.php
@@ -9,6 +9,8 @@ class ClassesListSource extends DataSourceBase {
 
     public static function handleClassList(array $classList, Output $output)
     {
+        $output->addData('class', $classList);
+
         foreach ($classList as $name) {
             $reflection = new ReflectionClass($name);
 

--- a/src/ClassesListSource.php
+++ b/src/ClassesListSource.php
@@ -40,6 +40,7 @@ class ClassesListSource extends DataSourceBase {
                 'interfaces' => [], // #todo
                 'constants' => [], // #todo
                 'properties' => [], // #todo
+                'traits' => [], // #todo
                 'methods' => [], // #todo
             ]);
         }

--- a/src/ClassesListSource.php
+++ b/src/ClassesListSource.php
@@ -2,8 +2,30 @@
 
 namespace PHPWatch\SymbolData;
 
+use ReflectionClass;
+
 class ClassesListSource extends DataSourceBase {
     const NAME = 'class';
+
+    public static function handleClassList(array $classList, Output $output)
+    {
+        foreach ($classList as $name) {
+            // Handle namespaces
+            $filename = str_replace('\\', '/', $name);
+
+            $reflection = new ReflectionClass($name);
+
+            $output->addData('classes/' . $filename, [
+                'type' => 'class',
+                'name' => $reflection->getName(),
+                'interfaces' => [], // #todo
+                'constants' => [], // #todo
+                'properties' => [], // #todo
+                'methods' => [], // #todo
+            ]);
+        }
+    }
+
     protected function gatherData() {
         $classes = get_declared_classes();
         $return = [];

--- a/src/ConstantsSource.php
+++ b/src/ConstantsSource.php
@@ -4,6 +4,82 @@ namespace PHPWatch\SymbolData;
 
 class ConstantsSource extends DataSourceBase {
     const NAME = 'const';
+
+    public static function handleGroupedConstantList(array $groupedContstList, Output $output)
+    {
+        foreach ($groupedContstList as $groupname => $constList) {
+            static::handleConstantList($groupname, $constList, $output);
+        }
+    }
+
+    private static function handleConstantList(string $groupname, array $constList, Output $output)
+    {
+        foreach ($constList as $name => $value) {
+            // Handle namespaces
+            $filename = str_replace('\\', '/', $name);
+            $metafile = realpath(__DIR__ . '/../meta/constants/' . $filename . '.php');
+
+            // maybe embed custom meta data
+            if ($metafile !== false && file_exists($metafile)) {
+                $meta = include($metafile);
+            } else {
+                // embed generic meta data
+                $meta = [
+                    'type' => 'constant',
+                    'name' => $name,
+                    'description' => '',
+                    'keywords' => [],
+                    'added' => '0.0',
+                    'deprecated' => null,
+                    'removed' => null,
+                    'resources' => static::generateResources($groupname, $name),
+                ];
+            }
+
+            $output->addData('constants/' . $filename, [
+                'type' => 'constant',
+                'name' => $name,
+                'meta' => $meta,
+                'value' => $value,
+                'extension' => $groupname,
+            ]);
+        }
+    }
+
+    private static function generateResources(string $groupname, string $name): array
+    {
+        $urls = [
+            'Core' => 'https://www.php.net/manual/reserved.constants.php',
+            'curl' => 'https://www.php.net/manual/curl.constants.php',
+            'date' => 'https://www.php.net/manual/class.datetimeinterface.php',
+        ];
+
+        if (! array_key_exists($groupname, $urls)) {
+            return [];
+        }
+
+        $url = $urls[$groupname];
+        $anchorName = 'constant.' . $name;
+
+        if ($groupname === 'date' && substr($name, 0, 5) === 'DATE_') {
+            $anchorName = 'datetimeinterface.constants.' . substr($name, 5);
+        }
+
+        if ($groupname === 'date' && substr($name, 0, 9) === 'SUNFUNCS_') {
+            $url = 'https://www.php.net/manual/function.date-sunrise.php';
+            $anchorName = 'refsect1-function.date-sunrise-parameters';
+        }
+
+        $anchorName = str_replace('_', '-', strtolower($anchorName));
+
+        return [
+            [
+                'name' => $name . ' constant (php.net)',
+                'url' => $url . '#' . $anchorName,
+            ],
+        ];
+    }
+
     protected function gatherData() {
         return get_defined_constants(true);
     }

--- a/src/ConstantsSource.php
+++ b/src/ConstantsSource.php
@@ -7,6 +7,8 @@ class ConstantsSource extends DataSourceBase {
 
     public static function handleGroupedConstantList(array $groupedContstList, Output $output)
     {
+        $output->addData('const', $groupedContstList);
+
         foreach ($groupedContstList as $groupname => $constList) {
             static::handleConstantList($groupname, $constList, $output);
         }

--- a/src/ExtensionListSource.php
+++ b/src/ExtensionListSource.php
@@ -9,6 +9,8 @@ class ExtensionListSource extends DataSourceBase {
 
     public static function handleExtensionList(array $extList, Output $output)
     {
+        $output->addData('ext', $extList);
+
         foreach ($extList as $name) {
             $reflection = new ReflectionExtension($name);
 

--- a/src/ExtensionListSource.php
+++ b/src/ExtensionListSource.php
@@ -51,6 +51,7 @@ class ExtensionListSource extends DataSourceBase {
         // ignore extenstions without manual entry
         if (in_array($extName, [
             'Core',
+            'standard',
         ])) {
             return [];
         }

--- a/src/ExtensionListSource.php
+++ b/src/ExtensionListSource.php
@@ -2,8 +2,67 @@
 
 namespace PHPWatch\SymbolData;
 
+use ReflectionExtension;
+
 class ExtensionListSource extends DataSourceBase {
     const NAME = 'ext';
+
+    public static function handleExtensionList(array $extList, Output $output)
+    {
+        foreach ($extList as $name) {
+            $reflection = new ReflectionExtension($name);
+
+            // Handle namespaces
+            $filename = str_replace('\\', '/', $name);
+            $metafile = realpath(__DIR__ . '/../meta/extensions/' . $filename . '.php');
+
+            // maybe embed custom meta data
+            if ($metafile !== false && file_exists($metafile)) {
+                $meta = include($metafile);
+            } else {
+                // embed generic meta data
+                $meta = [
+                    'type' => 'extension',
+                    'name' => $reflection->getName(),
+                    'description' => '',
+                    'keywords' => [],
+                    'added' => '0.0',
+                    'deprecated' => null,
+                    'removed' => null,
+                    'resources' => static::generateResources($name),
+                ];
+            }
+
+            $output->addData('extensions/' . $filename, [
+                'type' => 'extension',
+                'name' => $reflection->getName(),
+                'meta' => $meta,
+                'classes' => [], // #todo
+                'constants' => [], // #todo
+                'dependencies' => [], // #todo
+                'functions' => [], // #todo
+                'ini' => [], // #todo
+            ]);
+        }
+    }
+
+    private static function generateResources(string $extName): array
+    {
+        // ignore extenstions without manual entry
+        if (in_array($extName, [
+            'Core',
+        ])) {
+            return [];
+        }
+
+        return [
+            [
+                'name' => $extName . ' extension (php.net)',
+                'url' => 'https://www.php.net/manual/book.' . str_replace('\\', '-', strtolower($extName)) . '.php',
+            ],
+        ];
+    }
+
     protected function gatherData() {
         return get_loaded_extensions();
     }

--- a/src/FunctionsListSource.php
+++ b/src/FunctionsListSource.php
@@ -9,6 +9,8 @@ class FunctionsListSource extends DataSourceBase {
 
     public static function handleFunctionList(array $functionList, Output $output)
     {
+        $output->addData('function', $functionList);
+
         foreach ($functionList as $name) {
             $reflection = new ReflectionFunction($name);
 

--- a/src/FunctionsListSource.php
+++ b/src/FunctionsListSource.php
@@ -2,8 +2,58 @@
 
 namespace PHPWatch\SymbolData;
 
+use ReflectionFunction;
+
 class FunctionsListSource extends DataSourceBase {
     const NAME = 'function';
+
+    public static function handleFunctionList(array $functionList, Output $output)
+    {
+        foreach ($functionList as $name) {
+            $reflection = new ReflectionFunction($name);
+
+            // Handle namespaces
+            $filename = str_replace('\\', '/', $name);
+            $metafile = realpath(__DIR__ . '/../meta/functions/' . $filename . '.php');
+
+            // maybe embed custom meta data
+            if ($metafile !== false && file_exists($metafile)) {
+                $meta = include($metafile);
+            } else {
+                // embed generic meta data
+                $meta = [
+                    'type' => 'function',
+                    'name' => $reflection->getName(),
+                    'description' => '',
+                    'keywords' => [],
+                    'added' => '0.0',
+                    'deprecated' => null,
+                    'removed' => null,
+                    'resources' => static::generateResources($name),
+                ];
+            }
+
+            $output->addData('functions/' . $filename, [
+                'type' => 'function',
+                'name' => $reflection->getName(),
+                'meta' => $meta,
+                'parameters' => [], // #todo
+                'return' => [], // #todo
+                'extension' => $reflection->getExtensionName(),
+            ]);
+        }
+    }
+
+    private static function generateResources(string $name): array
+    {
+        return [
+            [
+                'name' => $name . ' function (php.net)',
+                'url' => 'https://www.php.net/manual/function.' . str_replace('_', '-', strtolower($name)) . '.php',
+            ],
+        ];
+    }
+
     protected function gatherData() {
         return get_defined_functions()['internal'];
     }

--- a/src/INIListSource.php
+++ b/src/INIListSource.php
@@ -4,6 +4,12 @@ namespace PHPWatch\SymbolData;
 
 class INIListSource extends DataSourceBase {
     const NAME = 'ini';
+
+    public static function handleIniList(array $iniList, Output $output)
+    {
+        $output->addData('ini', $iniList);
+    }
+
     protected function gatherData() {
         return ini_get_all();
     }

--- a/src/InterfacesListSource.php
+++ b/src/InterfacesListSource.php
@@ -2,8 +2,59 @@
 
 namespace PHPWatch\SymbolData;
 
+use ReflectionClass;
+
 class InterfacesListSource extends DataSourceBase {
     const NAME = 'interface';
+
+    public static function handleInterfaceList(array $interfaceList, Output $output)
+    {
+        foreach ($interfaceList as $name) {
+            $reflection = new ReflectionClass($name);
+
+            // Handle namespaces
+            $filename = str_replace('\\', '/', $name);
+            $metafile = realpath(__DIR__ . '/../meta/interfaces/' . $filename . '.php');
+
+            // maybe embed custom meta data
+            if ($metafile !== false && file_exists($metafile)) {
+                $meta = include($metafile);
+            } else {
+                // embed generic meta data
+                $meta = [
+                    'type' => 'interface',
+                    'name' => $reflection->getName(),
+                    'description' => '',
+                    'keywords' => [],
+                    'added' => '0.0',
+                    'deprecated' => null,
+                    'removed' => null,
+                    'resources' => static::generateResources($name),
+                ];
+            }
+
+            $output->addData('interfaces/' . $filename, [
+                'type' => 'interface',
+                'name' => $reflection->getName(),
+                'meta' => $meta,
+                'interfaces' => [], // #todo
+                'constants' => [], // #todo
+                'properties' => [], // #todo
+                'methods' => [], // #todo
+            ]);
+        }
+    }
+
+    private static function generateResources(string $name): array
+    {
+        return [
+            [
+                'name' => $name . ' interface (php.net)',
+                'url' => 'https://www.php.net/manual/class.' . str_replace('\\', '-', strtolower($name)) . '.php',
+            ],
+        ];
+    }
+
     protected function gatherData() {
         $interfaces = get_declared_interfaces();
         $return = [];

--- a/src/InterfacesListSource.php
+++ b/src/InterfacesListSource.php
@@ -9,6 +9,8 @@ class InterfacesListSource extends DataSourceBase {
 
     public static function handleInterfaceList(array $interfaceList, Output $output)
     {
+        $output->addData('interface', $interfaceList);
+
         foreach ($interfaceList as $name) {
             $reflection = new ReflectionClass($name);
 

--- a/src/Output.php
+++ b/src/Output.php
@@ -18,9 +18,15 @@ class Output {
         }
 
         foreach ($this->data as $key => $data) {
+            $filename = $this->dir . '/' . $key . '.php';
+
+            if (!is_dir(dirname($filename))) {
+                mkdir(dirname($filename), 0777, true);
+            }
+
             $data = var_export($data, true);
             $data = "<?php \n\nreturn " . $data . ";\n";
-            file_put_contents($this->dir . '/' . $key . '.php', $data);
+            file_put_contents($filename, $data);
         }
     }
 }

--- a/src/Output.php
+++ b/src/Output.php
@@ -19,7 +19,7 @@ class Output {
 
         foreach ($this->data as $key => $data) {
             $data = var_export($data, true);
-            $data = "<?php \r\n\r\nreturn " . $data;
+            $data = "<?php \n\nreturn " . $data . ";\n";
             file_put_contents($this->dir . '/' . $key . '.php', $data);
         }
     }

--- a/src/Output.php
+++ b/src/Output.php
@@ -19,7 +19,7 @@ class Output {
 
         foreach ($this->data as $key => $data) {
             $data = var_export($data, true);
-            $data = "<?php \n\nreturn " . $data . ";\n";
+            $data = "<?php\n\nreturn " . $data . ";\n";
             file_put_contents($this->dir . '/' . $key . '.php', $data);
         }
     }

--- a/src/PHPInfoSource.php
+++ b/src/PHPInfoSource.php
@@ -5,7 +5,12 @@ namespace PHPWatch\SymbolData;
 class PHPInfoSource extends DataSourceBase {
     const NAME = 'phpinfo';
 
-    private function postProcess(string $output): string {
+    public static function handlePhpinfoString(string $phpinfo, Output $output)
+    {
+        $output->addData('phpinfo', static::postProcess($phpinfo));
+    }
+
+    private static function postProcess(string $output): string {
         $re = '/^(Compiled|Build date)( => )(?<dynamic>.*?)$/mi';
         $subst = "$1$2__DYNAMIC__";
         return preg_replace($re, $subst, $output);
@@ -16,6 +21,6 @@ class PHPInfoSource extends DataSourceBase {
         // Do not include env of build info as they change in every build and run
         phpinfo(INFO_CREDITS|INFO_LICENSE|INFO_MODULES|INFO_CONFIGURATION);
         $return = ob_get_clean();
-        return $this->postProcess($return);
+        return static::postProcess($return);
     }
 }

--- a/src/TraitsListSource.php
+++ b/src/TraitsListSource.php
@@ -9,6 +9,8 @@ class TraitsListSource extends DataSourceBase {
 
     public static function handleTraitList(array $traitList, Output $output)
     {
+        $output->addData('trait', $traitList);
+
         foreach ($traitList as $name) {
             $reflection = new ReflectionClass($name);
 

--- a/src/TraitsListSource.php
+++ b/src/TraitsListSource.php
@@ -1,8 +1,51 @@
 <?php
 
 namespace PHPWatch\SymbolData;
+
+use ReflectionClass;
+
 class TraitsListSource extends DataSourceBase {
     const NAME = 'trait';
+
+    public static function handleTraitList(array $traitList, Output $output)
+    {
+        foreach ($traitList as $name) {
+            $reflection = new ReflectionClass($name);
+
+            // Handle namespaces
+            $filename = str_replace('\\', '/', $name);
+            $metafile = realpath(__DIR__ . '/../meta/traits/' . $filename . '.php');
+
+            // maybe embed custom meta data
+            if ($metafile !== false && file_exists($metafile)) {
+                $meta = include($metafile);
+            } else {
+                // embed generic meta data
+                $meta = [
+                    'type' => 'trait',
+                    'name' => $reflection->getName(),
+                    'description' => '',
+                    'keywords' => [],
+                    'added' => '0.0',
+                    'deprecated' => null,
+                    'removed' => null,
+                    'resources' => [],
+                ];
+            }
+
+            $output->addData('traits/' . $filename, [
+                'type' => 'trait',
+                'name' => $reflection->getName(),
+                'meta' => $meta,
+                'interfaces' => [], // #todo
+                'constants' => [], // #todo
+                'properties' => [], // #todo
+                'traits' => [], // #todo
+                'methods' => [], // #todo
+            ]);
+        }
+    }
+
     protected function gatherData() {
         return get_declared_traits();
     }


### PR DESCRIPTION
This PR requires #2 and creates new folders with more details about every class, interface, contstant, etc. At the moment it only creates a basic structure, that will be advanced with methods, parameter, etc in a future PR.

This PR also adds the possibility to add more meta data about every specific symbol, like `added`, `deprecated` or `removed`. This way we can add more data about every symbol that cannot be extracted from the Reflection API. The meta structure is inspired by the https://caniphp.com project. Maybe we should team up with them because they are working at the same goals?