### PR TITLE
Restore compatability with PHP <= 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Tests
 permissions: read-all
 on:
+  pull_request:
   push:
 
 jobs:

--- a/src/AttributesListSource.php
+++ b/src/AttributesListSource.php
@@ -57,29 +57,4 @@ class AttributesListSource extends DataSourceBase {
             ],
         ];
     }
-
-    protected function gatherData() {
-        if (!class_exists('Attribute', false)) {
-            return [];
-        }
-
-        $classes = get_declared_classes();
-        $return = [];
-
-        foreach ($classes as $class) {
-            if ($class === 'Attribute') {
-                continue;
-            }
-
-            $reflector = new ReflectionClass($class);
-            $attributes = $reflector->getAttributes();
-            foreach ($attributes as $attribute) {
-                if ($attribute->getName() === 'Attribute') {
-                    $return[] = $class;
-                }
-            }
-        }
-
-        return $return;
-    }
 }

--- a/src/ClassesListSource.php
+++ b/src/ClassesListSource.php
@@ -69,27 +69,4 @@ class ClassesListSource extends DataSourceBase {
             ],
         ];
     }
-
-    protected function gatherData() {
-        $classes = get_declared_classes();
-        $return = [];
-
-        foreach ($classes as $class) {
-            if (strpos($class, 'Composer\\') === 0) {
-                continue;
-            }
-
-            if (strpos($class, 'ComposerAutoloaderInit') === 0) {
-                continue;
-            }
-
-            if (strpos($class, 'PHPWatch\\') === 0) {
-                continue;
-            }
-
-            $return[] = $class;
-        }
-
-        return $return;
-    }
 }

--- a/src/ConstantsSource.php
+++ b/src/ConstantsSource.php
@@ -81,8 +81,4 @@ class ConstantsSource extends DataSourceBase {
             ],
         ];
     }
-
-    protected function gatherData() {
-        return get_defined_constants(true);
-    }
 }

--- a/src/DataSourceBase.php
+++ b/src/DataSourceBase.php
@@ -5,9 +5,8 @@ namespace PHPWatch\SymbolData;
 use ReflectionClass;
 
 abstract class DataSourceBase implements DataSourceInterface {
-    abstract protected function gatherData();
     public static function getAllData() {
-        return (new static())->gatherData();
+        return [];
     }
 
     protected static function generateDetailsAboutMethods(ReflectionClass $reflectionClass)

--- a/src/DataSourceBase.php
+++ b/src/DataSourceBase.php
@@ -63,7 +63,7 @@ abstract class DataSourceBase implements DataSourceInterface {
                 'is_public' => $property->isPublic(),
                 'is_protected' => $property->isProtected(),
                 'is_private' => $property->isPrivate(),
-                'is_promoted' => $property->isPromoted(),
+                'is_promoted' => (method_exists($property, 'isPromoted')) ? $property->isPromoted() : false,
             ];
         }
 

--- a/src/DataSourceBase.php
+++ b/src/DataSourceBase.php
@@ -5,6 +5,9 @@ namespace PHPWatch\SymbolData;
 use ReflectionClass;
 
 abstract class DataSourceBase implements DataSourceInterface {
+    /**
+     * @deprecated
+     */
     public static function getAllData() {
         return [];
     }
@@ -54,8 +57,8 @@ abstract class DataSourceBase implements DataSourceInterface {
                 'name' => $property->getName(),
                 'class' => $property->getDeclaringClass()->getName(),
                 'type' => ($property->getType() !== null) ? strval($property->getType()) : null,
-                'has_default_value' => $property->hasDefaultValue(),
-                'default_value' => $property->getDefaultValue(),
+                'has_default_value' => (method_exists($property, 'hasDefaultValue')) ? $property->hasDefaultValue() : false,
+                'default_value' => (method_exists($property, 'getDefaultValue')) ? $property->getDefaultValue() : null,
                 'is_static' => $property->isStatic(),
                 'is_public' => $property->isPublic(),
                 'is_protected' => $property->isProtected(),

--- a/src/DataSourceBase.php
+++ b/src/DataSourceBase.php
@@ -56,7 +56,7 @@ abstract class DataSourceBase implements DataSourceInterface {
             $properties[$property->getName()] = [
                 'name' => $property->getName(),
                 'class' => $property->getDeclaringClass()->getName(),
-                'type' => ($property->getType() !== null) ? strval($property->getType()) : null,
+                'type' => (method_exists($property, 'getType') && $property->getType() !== null) ? strval($property->getType()) : null,
                 'has_default_value' => (method_exists($property, 'hasDefaultValue')) ? $property->hasDefaultValue() : false,
                 'default_value' => (method_exists($property, 'getDefaultValue')) ? $property->getDefaultValue() : null,
                 'is_static' => $property->isStatic(),

--- a/src/DataSourceInterface.php
+++ b/src/DataSourceInterface.php
@@ -2,5 +2,8 @@
 
 namespace PHPWatch\SymbolData;
 interface DataSourceInterface {
+    /**
+     * @deprecated
+     */
     public static function getAllData();
 }

--- a/src/ExtensionListSource.php
+++ b/src/ExtensionListSource.php
@@ -65,8 +65,4 @@ class ExtensionListSource extends DataSourceBase {
             ],
         ];
     }
-
-    protected function gatherData() {
-        return get_loaded_extensions();
-    }
 }

--- a/src/FunctionsListSource.php
+++ b/src/FunctionsListSource.php
@@ -55,8 +55,4 @@ class FunctionsListSource extends DataSourceBase {
             ],
         ];
     }
-
-    protected function gatherData() {
-        return get_defined_functions()['internal'];
-    }
 }

--- a/src/INIListSource.php
+++ b/src/INIListSource.php
@@ -9,8 +9,4 @@ class INIListSource extends DataSourceBase {
     {
         $output->addData('ini', $iniList);
     }
-
-    protected function gatherData() {
-        return ini_get_all();
-    }
 }

--- a/src/InterfacesListSource.php
+++ b/src/InterfacesListSource.php
@@ -56,23 +56,4 @@ class InterfacesListSource extends DataSourceBase {
             ],
         ];
     }
-
-    protected function gatherData() {
-        $interfaces = get_declared_interfaces();
-        $return = [];
-
-        foreach ($interfaces as $interface) {
-            if (strpos($interface, 'Composer\\') === 0) {
-                continue;
-            }
-
-            if (strpos($interface, 'PHPWatch\\') === 0) {
-                continue;
-            }
-
-            $return[] = $interface;
-        }
-
-        return $return;
-    }
 }

--- a/src/PHPInfoSource.php
+++ b/src/PHPInfoSource.php
@@ -15,12 +15,4 @@ class PHPInfoSource extends DataSourceBase {
         $subst = "$1$2__DYNAMIC__";
         return preg_replace($re, $subst, $output);
     }
-
-    protected function gatherData() {
-        ob_start();
-        // Do not include env of build info as they change in every build and run
-        phpinfo(INFO_CREDITS|INFO_LICENSE|INFO_MODULES|INFO_CONFIGURATION);
-        $return = ob_get_clean();
-        return static::postProcess($return);
-    }
 }

--- a/src/TraitsListSource.php
+++ b/src/TraitsListSource.php
@@ -52,8 +52,4 @@ class TraitsListSource extends DataSourceBase {
             ]);
         }
     }
-
-    protected function gatherData() {
-        return get_declared_traits();
-    }
 }


### PR DESCRIPTION
#4 has broken the updates because of incompatibilities with PHP <= 7.4, because I didn't realize that I actively had to activate Github Actions in my repo. I'm really sorry about that. 😬 

This PR restores the compatibility and removes some unused code.

**Update**: I've also activated Github Actions on pull requests, so this accident should not happen again.