### PR TITLE
Remove class filter

### DIFF
--- a/bin/dump.php
+++ b/bin/dump.php
@@ -12,26 +12,61 @@ use PHPWatch\SymbolData\Sources\InterfacesListSource;
 use PHPWatch\SymbolData\Sources\PHPInfoSource;
 use PHPWatch\SymbolData\Sources\TraitsListSource;
 
-require __DIR__ . '/../vendor/autoload.php';
+function phpwatch_get_declared_functions() {
+    /** @noinspection PotentialMalwareInspection */
+    $funcs = get_defined_functions();
+    return $funcs['internal'];
+}
+
+function phpwatch_get_declared_attributes() {
+    $data = array();
+
+    if (PHP_VERSION_ID < 80000) {
+        return array();
+    }
+
+    if (!class_exists('Attribute', false)) {
+        return $data;
+    }
+
+    foreach (get_declared_classes() as $name) {
+        $reflection = new \ReflectionClass($name);
+
+        if ($reflection->getAttributes('Attribute') !== array()) {
+            $data[] = $reflection->getName();
+        }
+    }
+
+    return $data;
+}
+
+function phpwatch_get_phpinfo() {
+    ob_start();
+    // Do not include env of build info as they change in every build and run
+    phpinfo(INFO_CREDITS|INFO_LICENSE|INFO_MODULES|INFO_CONFIGURATION);
+    return ob_get_clean();
+}
 
 $PHPWatchSymbols = array(
     'ext' => get_loaded_extensions(),
     'const' => get_defined_constants(true),
     'class' => get_declared_classes(),
-    'trait' => PHP_VERSION_ID >= 50400 ? get_declared_traits() : null,
+    'trait' => PHP_VERSION_ID >= 50400 ? get_declared_traits() : array(),
     'interface' => get_declared_interfaces(),
-    'function' => FunctionsListSource::getData(),
+    'function' => phpwatch_get_declared_functions(),
     'ini' => ini_get_all(),
-    'attribute' => AttributesListSource::getData(),
-    'phpinfo' => PHPInfoSource::getData(),
+    'attribute' => phpwatch_get_declared_attributes(),
+    'phpinfo' => phpwatch_get_phpinfo(),
 );
+
+require __DIR__ . '/../vendor/autoload.php';
 
 $dumper = new Dumper(new Output());
 
 $dumper->addSource(new ExtensionListSource($PHPWatchSymbols['ext']));
 $dumper->addSource(new ConstantsSource($PHPWatchSymbols['const']));
 $dumper->addSource(new ClassesListSource($PHPWatchSymbols['class']));
-$dumper->addSource(new TraitsListSource(isset($PHPWatchSymbols['trait']) ? $PHPWatchSymbols['trait'] : array()));
+$dumper->addSource(new TraitsListSource($PHPWatchSymbols['trait']));
 $dumper->addSource(new InterfacesListSource($PHPWatchSymbols['interface']));
 $dumper->addSource(new FunctionsListSource($PHPWatchSymbols['function']));
 $dumper->addSource(new INIListSource($PHPWatchSymbols['ini']));

--- a/src/Sources/AttributesListSource.php
+++ b/src/Sources/AttributesListSource.php
@@ -19,28 +19,6 @@ class AttributesListSource extends DataSourceBase implements DataSource {
         $this->data = $data;
     }
 
-    public static function getData() {
-        $data = array();
-
-        if (PHP_VERSION_ID < 80000) {
-            return array();
-        }
-
-        if (!class_exists('Attribute', false)) {
-            return $data;
-        }
-
-        foreach (get_declared_classes() as $name) {
-            $reflection = new \ReflectionClass($name);
-
-            if ($reflection->getAttributes('Attribute') !== array()) {
-                $data[] = $reflection->getName();
-            }
-        }
-
-        return $data;
-    }
-
     public function addDataToOutput(Output $output) {
         static::handleAttributeList($this->data, $output);
     }

--- a/src/Sources/ClassesListSource.php
+++ b/src/Sources/ClassesListSource.php
@@ -16,12 +16,7 @@ class ClassesListSource extends DataSourceBase implements DataSource {
     private $data;
 
     public function __construct(array $data) {
-        $data = array_filter($data, '\PHPWatch\SymbolData\Sources\ClassesListSource::filterClassList');
         $this->data = $data;
-    }
-
-    public static function filterClassList($class) {
-        return strpos($class, 'Composer') !== 0;
     }
 
     public function addDataToOutput(Output $output) {

--- a/src/Sources/FunctionsListSource.php
+++ b/src/Sources/FunctionsListSource.php
@@ -19,12 +19,6 @@ class FunctionsListSource extends DataSourceBase implements DataSource {
         $this->data = $data;
     }
 
-    public static function getData() {
-        /** @noinspection PotentialMalwareInspection */
-        $funcs = get_defined_functions();
-        return $funcs['internal'];
-    }
-
     public function addDataToOutput(Output $output) {
         static::handleFunctionList($this->data, $output);
     }

--- a/src/Sources/PHPInfoSource.php
+++ b/src/Sources/PHPInfoSource.php
@@ -22,13 +22,6 @@ class PHPInfoSource extends DataSourceBase implements DataSource {
         static::handlePhpinfoString($this->data, $output);
     }
 
-    public static function getData() {
-        ob_start();
-        // Do not include env of build info as they change in every build and run
-        phpinfo(INFO_CREDITS|INFO_LICENSE|INFO_MODULES|INFO_CONFIGURATION);
-        return ob_get_clean();
-    }
-
     private static function handlePhpinfoString($phpinfo, Output $output) {
         $output->addData('phpinfo', static::postProcess($phpinfo));
     }


### PR DESCRIPTION
https://github.com/PHPWatch/symbol-data-builder/commit/d154f87273e9a55f3fe50ef799a50e540de112a5#r140005041

> moving this functions into the source classes requires the call of `require __DIR__ . '/../vendor/autoload.php';` upfront. This leads to the need of adding filter for the Composer classes in [7ff5780](https://github.com/PHPWatch/symbol-data-builder/commit/7ff5780f3eb5bd4301f8799dfc105b5ff4a3f36b) and will create more problems in the future.
> 
> For PHP 5.3 compat I recommend to move this code into separate functions declared upfront in this dump.php file or we can extract them into a separate `functions.php` file. Because we are using `get_defined_functions()['internal']` to get the function list our own functions will be ignored.

In this PR I remove the need for filtering the class list.